### PR TITLE
Ticket-16 Add linkedin input to preview card

### DIFF
--- a/src/components/FillCollapsible.js
+++ b/src/components/FillCollapsible.js
@@ -104,6 +104,8 @@ function FillCollapsible(props) {
             Linkedin
           </label>
           <input
+            onChange={props.actionToPerform}
+            value={props.dataUser.linkedin}
             className="item__info"
             type="url"
             id="linkedin"

--- a/src/components/PreviewCard.js
+++ b/src/components/PreviewCard.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PreviewName from './PreviewName';
 import PreviewJob from './PreviewJob';
+import PreviewLinkedin from './PreviewLinkedin';
 
 class PreviewCard extends React.Component {
 	render() {
@@ -32,14 +33,7 @@ class PreviewCard extends React.Component {
 						</a>
 					</li>
 
-					<li className="social__icons linkedin-icon">
-						{' '}
-						<a className="linkedin-link" href="" target="_blank">
-							<svg className="wrap-icon">
-								<use href="#ico-linkedin" />
-							</svg>
-						</a>
-					</li>
+					<PreviewLinkedin linkedin={this.props.dataUser.linkedin} />
 
 					<li className="social__icons github-icon">
 						{' '}

--- a/src/components/PreviewLinkedin.js
+++ b/src/components/PreviewLinkedin.js
@@ -1,0 +1,22 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+class PreviewLinkedin extends React.Component {
+  render() {
+    return (
+      <li className="social__icons linkedin-icon">
+        {" "}
+        <a className="linkedin-link" href={this.props.linkedin ? `https://www.linkedin.com/in/${this.props.linkedin}` : ''} target= " blank">
+          <svg className="wrap-icon">
+            <use href="#ico-linkedin" />
+          </svg>
+        </a>
+      </li>
+    );
+  }
+}
+
+PreviewLinkedin.propTypes = {
+  linkedin: PropTypes.string.isRequired
+};
+export default PreviewLinkedin;


### PR DESCRIPTION
Add small feature to modify dataUser `linkedin` in state from input and show it in the preview card: 

-Add a new `PreviewLinkedin.js` file with that paints the href attribute with the general link + linkedin user.
-Import `PreviewLinkedin` in `PreviewCard`.
-Add value and listener (lifting) in linkedin input in `FillCollapsible`

Please, review! :)