### PR TITLE
add box-shadow to social media icons

### DIFF
--- a/src/components/PreviewEmail.js
+++ b/src/components/PreviewEmail.js
@@ -3,8 +3,13 @@ import React from 'react';
 class PreviewEmail extends React.Component {
 	render() {
 		return (
-			<li className="social__icons email-icon">
-				{' '}
+			<li
+				className={
+					this.props.email
+						? `social__icons email-icon addBoxShadow__IfInputIsFIlled`
+						: 'social__icons email-icon '
+				}
+			>
 				<a
 					href={this.props.email ? `mailto:${this.props.email}` : ''}
 					className="email__card"

--- a/src/components/PreviewGithub.js
+++ b/src/components/PreviewGithub.js
@@ -1,31 +1,36 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class PreviewGithub extends React.Component {
-  render() {
-    return (
-      <li className="social__icons github-icon">
-        {" "}
-        <a
-          className="link-github"
-          href={
-            this.props.githubUser
-              ? `https://github.com/${this.props.githubUser}`
-              : ""
-          }
-          target="_blank"
-        >
-          <svg className="wrap-icon">
-            <use href="#ico-github" />
-          </svg>
-        </a>
-      </li>
-    );
-  }
+	render() {
+		return (
+			<li
+				className={
+					this.props.githubUser
+						? `social__icons github-icon addBoxShadow__IfInputIsFIlled`
+						: 'social__icons github-icon '
+				}
+			>
+				<a
+					className="link-github"
+					href={
+						this.props.githubUser
+							? `https://github.com/${this.props.githubUser}`
+							: ''
+					}
+					target="_blank"
+				>
+					<svg className="wrap-icon">
+						<use href="#ico-github" />
+					</svg>
+				</a>
+			</li>
+		);
+	}
 }
 
 PreviewGithub.propTypes = {
-  githubUser: PropTypes.string.isRequired
+	githubUser: PropTypes.string.isRequired
 };
 
 export default PreviewGithub;

--- a/src/components/PreviewLinkedin.js
+++ b/src/components/PreviewLinkedin.js
@@ -1,22 +1,35 @@
-import React from "react";
-import PropTypes from "prop-types";
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class PreviewLinkedin extends React.Component {
-  render() {
-    return (
-      <li className="social__icons linkedin-icon">
-        {" "}
-        <a className="linkedin-link" href={this.props.linkedin ? `https://www.linkedin.com/in/${this.props.linkedin}` : ''} target= " blank">
-          <svg className="wrap-icon">
-            <use href="#ico-linkedin" />
-          </svg>
-        </a>
-      </li>
-    );
-  }
+	render() {
+		return (
+			<li
+				className={
+					this.props.linkedin
+						? `social__icons linkedin-icon addBoxShadow__IfInputIsFIlled`
+						: 'social__icons linkedin-icon'
+				}
+			>
+				<a
+					className="linkedin-link"
+					href={
+						this.props.linkedin
+							? `https://www.linkedin.com/in/${this.props.linkedin}`
+							: ''
+					}
+					target=" blank"
+				>
+					<svg className="wrap-icon">
+						<use href="#ico-linkedin" />
+					</svg>
+				</a>
+			</li>
+		);
+	}
 }
 
 PreviewLinkedin.propTypes = {
-  linkedin: PropTypes.string.isRequired
+	linkedin: PropTypes.string.isRequired
 };
 export default PreviewLinkedin;

--- a/src/components/PreviewMobile.js
+++ b/src/components/PreviewMobile.js
@@ -3,8 +3,13 @@ import React, { Component } from 'react';
 class PreviewMobile extends React.Component {
 	render() {
 		return (
-			<li className="social__icons mobile-icon">
-				{' '}
+			<li
+				className={
+					this.props.phone
+						? `social__icons mobile-icon addBoxShadow__IfInputIsFIlled`
+						: 'social__icons mobile-icon'
+				}
+			>
 				<a
 					href={this.props.phone ? `tel:${this.props.phone}` : ''}
 					id="mobile-link"


### PR DESCRIPTION
hello, in the files: previewEmail, previewLinkedin, previewGithub, previewPhone i added a ternary for the icons (at each li) if there are props for that element, the class addBoxShadow__IfInputIsFIlled it's being added else it remains with the class that it already had.